### PR TITLE
Add additional rustdocs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "linked_list_allocator"
@@ -25,10 +25,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -56,20 +57,20 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -98,17 +99,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+//! Testsuite for a wide variety of N64 features and behaviors.
+//! 
+//! All tests included in this suite are found in the [`tests`] module.
+
 #![no_std]
 #![feature(alloc_error_handler)]
 #![feature(asm_const)]
@@ -7,6 +11,7 @@
 #![feature(type_name_of_val)]
 #![feature(step_trait)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![allow(rustdoc::private_intra_doc_links)]
 #![no_main]
 
 extern crate alloc;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -26,34 +26,46 @@ mod testlist;
 mod tlb;
 mod traps;
 
+/// The importance level of a [test](Test).
 #[derive(Eq, PartialEq)]
 pub enum Level {
-    // Very basic functionality - if this is broken, expect things to go bad
+    /// Very basic functionality. If this is broken, expect things to go bad.
     BasicFunctionality,
 
-    // Basic functionality that is rarely used
+    /// Rarely used basic functionality.
     RarelyUsed,
 
-    // Some weird hardware quirk - this probably won't matter too much
+    /// A weird hardware quirk. This probably won't matter too much.
     Weird,
 
-    // Some hardware quirk that is so weird that the test won't be run by default
+    /// A hardware quirk that is so weird that the test won't be run by default.
     TooWeird,
 
-    // Basic functionality, but extremely slow so not run by default
+    /// Slow test of basic functionality. Only enabled when compiled with stresstest feature flags.
     StressTest,
 }
 
+/// Trait for a test or group of tests that are performed together.
 pub trait Test {
+    /// Human-readable name for the test.
     fn name(&self) -> &str;
 
+    /// Returns the [level](Level) of the test.
+    /// 
+    /// Some levels may be filtered out of the compiled test rom by default.
     fn level(&self) -> Level;
 
-    /// Returns a set of values to run the test with.
-    /// Tests that don't support multiple values can return an empty Vec and will still
-    /// get called once, in which case the value argument should be ignored
+    /// Returns a list of values to run the test with.
+    /// 
+    /// If the list is empty, the test will only be run once, using a dummy value. Otherwise, the
+    /// test will be run once for every value in the list.
     fn values(&self) -> Vec<Box<dyn Any>>;
 
+    /// Run the test with a provide value.
+    /// 
+    /// Value may be a dummy, if [`Self::values()`] returned an empty list.
+    /// 
+    /// If the test fails, return a human-readable description of the issue.
     fn run(&self, value: &Box<dyn Any>) -> Result<(), String>;
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -61,7 +61,7 @@ pub trait Test {
     /// test will be run once for every value in the list.
     fn values(&self) -> Vec<Box<dyn Any>>;
 
-    /// Run the test with a provide value.
+    /// Run the test with a provided value.
     /// 
     /// Value may be a dummy, if [`Self::values()`] returned an empty list.
     /// 

--- a/src/tests/soft_asserts.rs
+++ b/src/tests/soft_asserts.rs
@@ -12,7 +12,8 @@ pub fn soft_assert_eq<T: Debug + PartialEq + Eq>(v1: T, v2: T, help: &str) -> Re
     }
 }
 
-/// Inlined test of whether `v1 == v2`.
+/// Inlined test of whether `v1 == v2`. Similar to [`soft_assert_eq`] but the help message on failure
+/// is provided via a closure/fn instead of a `&str`.
 #[inline(always)]
 pub fn soft_assert_eq2<T: Debug + PartialEq + Eq, H: FnOnce() -> String>(v1: T, v2: T, help: H) -> Result<(), String> {
     if v1 == v2 {
@@ -22,7 +23,8 @@ pub fn soft_assert_eq2<T: Debug + PartialEq + Eq, H: FnOnce() -> String>(v1: T, 
     }
 }
 
-/// Inlined test of whether [vectors](Vector) `v1 == v2`.
+/// Inlined test of whether [vectors](Vector) `v1 == v2`, Equivalent to [`soft_assert_eq2`] but prints
+/// a more readable error message on failure.
 #[inline(always)]
 pub fn soft_assert_eq_vector<H: FnOnce() -> String>(actual: Vector, expected: Vector, help: H) -> Result<(), String> {
     if actual == expected {

--- a/src/tests/soft_asserts.rs
+++ b/src/tests/soft_asserts.rs
@@ -3,6 +3,7 @@ use alloc::string::String;
 use core::fmt::{Debug, Display, LowerHex};
 use crate::math::vector::Vector;
 
+/// Tests if `v1 == v2`.
 pub fn soft_assert_eq<T: Debug + PartialEq + Eq>(v1: T, v2: T, help: &str) -> Result<(), String> {
     if v1 == v2 {
         Ok(())
@@ -11,6 +12,7 @@ pub fn soft_assert_eq<T: Debug + PartialEq + Eq>(v1: T, v2: T, help: &str) -> Re
     }
 }
 
+/// Inlined test of whether `v1 == v2`.
 #[inline(always)]
 pub fn soft_assert_eq2<T: Debug + PartialEq + Eq, H: FnOnce() -> String>(v1: T, v2: T, help: H) -> Result<(), String> {
     if v1 == v2 {
@@ -20,6 +22,7 @@ pub fn soft_assert_eq2<T: Debug + PartialEq + Eq, H: FnOnce() -> String>(v1: T, 
     }
 }
 
+/// Inlined test of whether [vectors](Vector) `v1 == v2`.
 #[inline(always)]
 pub fn soft_assert_eq_vector<H: FnOnce() -> String>(actual: Vector, expected: Vector, help: H) -> Result<(), String> {
     if actual == expected {
@@ -30,6 +33,7 @@ pub fn soft_assert_eq_vector<H: FnOnce() -> String>(actual: Vector, expected: Ve
     }
 }
 
+/// Tests if `v1 != v2`.
 pub fn soft_assert_neq<T: Display + LowerHex + PartialEq + Eq>(v1: T, v2: T, help: &str) -> Result<(), String> {
     if v1 != v2 {
         Ok(())
@@ -38,6 +42,7 @@ pub fn soft_assert_neq<T: Display + LowerHex + PartialEq + Eq>(v1: T, v2: T, hel
     }
 }
 
+/// Tests if `v1 >= v2`.
 pub fn soft_assert_greater_or_equal(v1: u32, v2: u32, help: &str) -> Result<(), String> {
     if v1 >= v2 {
         Ok(())
@@ -46,6 +51,7 @@ pub fn soft_assert_greater_or_equal(v1: u32, v2: u32, help: &str) -> Result<(), 
     }
 }
 
+/// Tests if `v1 < v2`.
 pub fn soft_assert_less(v1: u32, v2: u32, help: &str) -> Result<(), String> {
     if v1 < v2 {
         Ok(())

--- a/src/tests/testlist.rs
+++ b/src/tests/testlist.rs
@@ -436,6 +436,7 @@ fn default_tests() -> Vec<Box<dyn Test>> {
     vec! {}
 }
 
+/// Returns a list of tests to be performed.
 pub fn tests() -> Vec<Box<dyn Test>> {
     let mut result = default_tests();
     append_stress_tests(&mut result);


### PR DESCRIPTION
Adds some docs to commonly used methods and structures.

While this isn't a crate, rustdocs are still helpful for new developers who are learning the codebase (such as myself). IDE's and editors that support Rust, typically have some way of rendering these docs. Otherwise devs can run `cargo doc` to generate the Rust standard web-based docs (`/target/doc/n64_systemtest/index.html`).