### PR TITLE
Add CycleExact level

### DIFF
--- a/src/tests/cop0/mod.rs
+++ b/src/tests/cop0/mod.rs
@@ -29,7 +29,7 @@ pub struct RandomDecrement;
 impl Test for RandomDecrement {
     fn name(&self) -> &str { "Random (decrement)" }
 
-    fn level(&self) -> Level { Level::BasicFunctionality }
+    fn level(&self) -> Level { Level::CycleExact }
 
     fn values(&self) -> Vec<Box<dyn Any>> { Vec::new() }
 
@@ -118,7 +118,7 @@ pub struct RandomMasking;
 impl Test for RandomMasking {
     fn name(&self) -> &str { "Random (masking)" }
 
-    fn level(&self) -> Level { Level::Weird }
+    fn level(&self) -> Level { Level::CycleExact }
 
     fn values(&self) -> Vec<Box<dyn Any>> { Vec::new() }
 
@@ -159,7 +159,7 @@ pub struct RandomReadEarly;
 impl Test for RandomReadEarly {
     fn name(&self) -> &str { "Random (read early)" }
 
-    fn level(&self) -> Level { Level::TooWeird }
+    fn level(&self) -> Level { Level::CycleExact }
 
     fn values(&self) -> Vec<Box<dyn Any>> { Vec::new() }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -43,6 +43,10 @@ pub enum Level {
 
     /// Slow test of basic functionality. Only enabled when compiled with stresstest feature flags.
     StressTest,
+
+    /// A test which documents a behavior of the hardware which makes sense in the context of cycle-exact emulation
+    /// (not deemed practical for current software emulators)
+    CycleExact,
 }
 
 /// Trait for a test or group of tests that are performed together.
@@ -124,7 +128,7 @@ pub fn run() {
             return " with unknown arguments".to_string();
         }
 
-        if test.level() == Level::TooWeird {
+        if test.level() == Level::TooWeird || test.level() == Level::CycleExact {
             *skipped += 1
         } else {
             // Kernel mode, erl/exl off. 32 bit addressing mode. Tests that want to test something else


### PR DESCRIPTION
This commit adds a CycleExact level for tests which document behavior
of the hardware which makes sense in the context of cycle-exact emulation.