### PR TITLE
Builder feature parity with old makefile

### DIFF
--- a/builder/src/main.rs
+++ b/builder/src/main.rs
@@ -37,7 +37,11 @@ fn main() {
     let elf = nust64::elf::Elf::build(&PathBuf::from("n64-systemtest"), Some(&features)).unwrap();
     let rom = nust64::rom::Rom::new(&elf, ipl3.try_into().expect("Failed to cast into array. Is input not exactly 4032 bytes?"), Some(ROM_TITLE));
     
-    std::fs::write(FILE_NAME, rom.to_vec()).unwrap();
+    let outpath = PathBuf::from(FILE_NAME);
+    match std::fs::write(&outpath, rom.to_vec()) {
+        Ok(_) => println!("Rom successfully compiled: {}", outpath.canonicalize().unwrap_or(outpath).display()),
+        Err(err) => panic!("Unable to save rom file: {}", err)
+    }
     
     
     if matches.is_present("unfloader") {

--- a/builder/src/main.rs
+++ b/builder/src/main.rs
@@ -1,8 +1,12 @@
 use std::path::PathBuf;
-use clap::{AppSettings, Arg, Command};
+use std::process::{Command, Stdio};
+use clap::{AppSettings, Arg};
+
+const ROM_TITLE: &'static str = "n64-systemtest";
+const FILE_NAME: &'static str = "n64-systemtest.n64";
 
 fn main() {
-    let matches = Command::new("n64-systemtest builder")
+    let matches = clap::Command::new("n64-systemtest builder")
         .arg(Arg::new("ipl3")
             .takes_value(true)
             .long("ipl3")
@@ -10,8 +14,15 @@ fn main() {
         .arg(Arg::new("features")
             .takes_value(true)
             .long("features")
+            .help("Specify list of feature flags which enable different tests. Multiple values allowed.")
             .multiple_values(true)
             .allow_invalid_utf8(true))
+        .arg(Arg::new("unfloader")
+            .long("unf")
+            .help("Will upload with UNFLoader using successfully built rom."))
+        .arg(Arg::new("usb64")
+            .long("usb64")
+            .help("Will upload with usb64 using successfully built rom."))
         .global_setting(AppSettings::DeriveDisplayOrder)
         .next_line_help(true)
         .get_matches();
@@ -24,7 +35,24 @@ fn main() {
     let features = &features.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
     
     let elf = nust64::elf::Elf::build(&PathBuf::from("n64-systemtest"), Some(&features)).unwrap();
-    let rom = nust64::rom::Rom::new(&elf, ipl3.try_into().expect("Failed to cast into array. Is input not exactly 4032 bytes?"), None);
+    let rom = nust64::rom::Rom::new(&elf, ipl3.try_into().expect("Failed to cast into array. Is input not exactly 4032 bytes?"), Some(ROM_TITLE));
     
-    std::fs::write("n64-systemtest.n64", rom.to_vec()).unwrap();
+    std::fs::write(FILE_NAME, rom.to_vec()).unwrap();
+    
+    
+    if matches.is_present("unfloader") {
+        Command::new("UNFLoader")
+            .args(["-r", FILE_NAME])
+            .stderr(Stdio::inherit())
+            .status()
+            .expect("Failed to execute UNFLoader");
+    }
+    
+    if matches.is_present("usb64") {
+        Command::new("usb64")
+            .args([&format!("-rom={}", FILE_NAME), "-start"])
+            .stderr(Stdio::inherit())
+            .status()
+            .expect("Failed to execute UNFLoader");
+    }
 }


### PR DESCRIPTION
Small PR to implement a few options that were missing compared to the old makefile.

- Added a message upon successfully building and saving the rom, which tells the user where the rom was saved to.
- Added arguments for running the finished rom with usb64 and unfloader.

The makefile appeared to have a way [to start some undefined emulator](https://github.com/lemmy-64/n64-systemtest/blob/5fb0574a24bfd2a05e80b27d3e6e93d1811294f5/Makefile#L28), but I didn't port this because not every emulator's CLI interface works the same way.

There was also a command to build the mini-ipl3 source. But since it's highly unlikely a non-contributor would need to edit that, and the compiled binary is included in the repo, adding this command doesn't seem necessary. Plus, it's very possible the user doesn't have `bass` installed on their PATH or at all.

There is a problem with discoverability of what feature flags are available. But this should be resolved in later PR(s) that rework test selection. (For now, people can look at n64-systemtest's Cargo.toml, even though it isn't user-friendly.)