### PR TITLE
Add more pifram SB tests for all possible unaligned accesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "n64-systemtest"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "arrayref",
  "linked_list_allocator",

--- a/n64-systemtest/Cargo.toml
+++ b/n64-systemtest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "n64-systemtest"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 
 [features]

--- a/n64-systemtest/src/tests/pif_memory/mod.rs
+++ b/n64-systemtest/src/tests/pif_memory/mod.rs
@@ -90,10 +90,38 @@ impl Test for SH2 {
     }
 }
 
-pub struct SB {}
+pub struct SB0 {}
 
-impl Test for SB {
-    fn name(&self) -> &str { "pifram: SB" }
+impl Test for SB0 {
+    fn name(&self) -> &str { "pifram: SB (offset 0)" }
+
+    fn level(&self) -> Level { Level::Weird }
+
+    fn values(&self) -> Vec<Box<dyn Any>> { Vec::new() }
+
+    fn run(&self, _value: &Box<dyn Any>) -> Result<(), String> {
+        let pifram = MemoryMap::uncached_pifram_address::<u32>(0x0);
+
+        unsafe {
+            asm!("
+                .set noat
+                .set noreorder
+
+                LUI $3, 0x1234
+                ORI $3, $3, 0x5678
+                SB $3, 0($2)
+            ", in("$2") pifram, out("$3") _)
+        }
+
+        soft_assert_eq(unsafe { pifram.add(0).read_volatile() }, 0x78000000, "Reading 32 bit from PIFRAM[0]")?;
+        Ok(())
+    }
+}
+
+pub struct SB1 {}
+
+impl Test for SB1 {
+    fn name(&self) -> &str { "pifram: SB (offset 1)" }
 
     fn level(&self) -> Level { Level::Weird }
 
@@ -114,6 +142,62 @@ impl Test for SB {
         }
 
         soft_assert_eq(unsafe { pifram.add(0).read_volatile() }, 0x56780000, "Reading 32 bit from PIFRAM[0]")?;
+        Ok(())
+    }
+}
+
+pub struct SB2 {}
+
+impl Test for SB2 {
+    fn name(&self) -> &str { "pifram: SB (offset 2)" }
+
+    fn level(&self) -> Level { Level::Weird }
+
+    fn values(&self) -> Vec<Box<dyn Any>> { Vec::new() }
+
+    fn run(&self, _value: &Box<dyn Any>) -> Result<(), String> {
+        let pifram = MemoryMap::uncached_pifram_address::<u32>(0x0);
+
+        unsafe {
+            asm!("
+                .set noat
+                .set noreorder
+
+                LUI $3, 0x1234
+                ORI $3, $3, 0x5678
+                SB $3, 2($2)
+            ", in("$2") pifram, out("$3") _)
+        }
+
+        soft_assert_eq(unsafe { pifram.add(0).read_volatile() }, 0x34567800, "Reading 32 bit from PIFRAM[0]")?;
+        Ok(())
+    }
+}
+
+pub struct SB3 {}
+
+impl Test for SB3 {
+    fn name(&self) -> &str { "pifram: SB (offset 3)" }
+
+    fn level(&self) -> Level { Level::Weird }
+
+    fn values(&self) -> Vec<Box<dyn Any>> { Vec::new() }
+
+    fn run(&self, _value: &Box<dyn Any>) -> Result<(), String> {
+        let pifram = MemoryMap::uncached_pifram_address::<u32>(0x0);
+
+        unsafe {
+            asm!("
+                .set noat
+                .set noreorder
+
+                LUI $3, 0x1234
+                ORI $3, $3, 0x5678
+                SB $3, 3($2)
+            ", in("$2") pifram, out("$3") _)
+        }
+
+        soft_assert_eq(unsafe { pifram.add(0).read_volatile() }, 0x12345678, "Reading 32 bit from PIFRAM[0]")?;
         Ok(())
     }
 }

--- a/n64-systemtest/src/tests/testlist.rs
+++ b/n64-systemtest/src/tests/testlist.rs
@@ -508,7 +508,10 @@ fn default_tests() -> Vec<Box<dyn Test>> {
         Box::new(super::pif_memory::SW {}),
         Box::new(super::pif_memory::SH0 {}),
         Box::new(super::pif_memory::SH2 {}),
-        Box::new(super::pif_memory::SB {}),
+        Box::new(super::pif_memory::SB0 {}),
+        Box::new(super::pif_memory::SB1 {}),
+        Box::new(super::pif_memory::SB2 {}),
+        Box::new(super::pif_memory::SB3 {}),
         Box::new(super::pif_memory::LB {}),
         Box::new(super::pif_memory::LH {}),
 


### PR DESCRIPTION
Results verified on a US N64 with an EverDrive X7