### PR TITLE
Fix broken CVT.L.W test.

### DIFF
--- a/src/tests/cop1/mod.rs
+++ b/src/tests/cop1/mod.rs
@@ -2980,7 +2980,7 @@ impl Test for ConvertToL {
             Box::new((FConst::SUBNORMAL_MAX_NEGATIVE_64, expected_unimplemented_i64())),
 
             // W => L (which doesn't exist)
-            Box::new((4i64, expected_unimplemented_i64())),
+            Box::new((4i32, expected_unimplemented_i64())),
 
             // L => L (which doesn't exist)
             Box::new((4i64, expected_unimplemented_i64())),

--- a/src/tests/cop1/mod.rs
+++ b/src/tests/cop1/mod.rs
@@ -1051,11 +1051,11 @@ impl Test for DivS {
             Box::new((true, FCSRRoundingMode::Nearest, FConst::SUBNORMAL_MIN_POSITIVE_32, 1f32, expected_unimplemented_f32())),
             Box::new((true, FCSRRoundingMode::Nearest, FConst::SUBNORMAL_MAX_POSITIVE_32, 1f32, expected_unimplemented_f32())),
             Box::new((true, FCSRRoundingMode::Nearest, FConst::SUBNORMAL_MIN_NEGATIVE_32, 1f32, expected_unimplemented_f32())),
-            Box::new((true, FCSRRoundingMode::Nearest, FConst::SUBNORMAL_MIN_NEGATIVE_32, 1f32, expected_unimplemented_f32())),
+            Box::new((true, FCSRRoundingMode::Nearest, FConst::SUBNORMAL_MAX_NEGATIVE_32, 1f32, expected_unimplemented_f32())),
             Box::new((true, FCSRRoundingMode::Nearest, 0f32, FConst::SUBNORMAL_MIN_POSITIVE_32, expected_unimplemented_f32())),
             Box::new((true, FCSRRoundingMode::Nearest, 0f32, FConst::SUBNORMAL_MAX_POSITIVE_32, expected_unimplemented_f32())),
             Box::new((true, FCSRRoundingMode::Nearest, 0f32, FConst::SUBNORMAL_MIN_NEGATIVE_32, expected_unimplemented_f32())),
-            Box::new((true, FCSRRoundingMode::Nearest, 0f32, FConst::SUBNORMAL_MIN_NEGATIVE_32, expected_unimplemented_f32())),
+            Box::new((true, FCSRRoundingMode::Nearest, 0f32, FConst::SUBNORMAL_MAX_NEGATIVE_32, expected_unimplemented_f32())),
             Box::new((true, FCSRRoundingMode::Nearest, FConst::SUBNORMAL_MIN_NEGATIVE_32, FConst::SUBNORMAL_MIN_NEGATIVE_32, expected_unimplemented_f32())),
 
             // 0/0 gives an invalid operation and produces a specific nan result

--- a/src/tests/cop1/mod.rs
+++ b/src/tests/cop1/mod.rs
@@ -2610,7 +2610,7 @@ impl Test for CvtD {
 pub struct ConvertToW;
 
 impl Test for ConvertToW {
-    fn name(&self) -> &str { "COP1: CVT.W, ROUND.W, TRUNC.W, CEIL.W" }
+    fn name(&self) -> &str { "COP1: CVT.W, ROUND.W, TRUNC.W, FLOOR.W, CEIL.W" }
 
     fn level(&self) -> Level { Level::BasicFunctionality }
 
@@ -2856,7 +2856,7 @@ impl Test for ConvertToW {
 pub struct ConvertToL;
 
 impl Test for ConvertToL {
-    fn name(&self) -> &str { "COP1: CVT.L, ROUND.L, TRUNC.L, CEIL.L" }
+    fn name(&self) -> &str { "COP1: CVT.L, ROUND.L, TRUNC.L, FLOOR.L, CEIL.L" }
 
     fn level(&self) -> Level { Level::BasicFunctionality }
 


### PR DESCRIPTION
I wondered why CVT.L.W was never being executed on my emulator and it looks like this test was set up incorrectly and was duplicating the CVT.L.L test.