### PR TITLE
Add test for RSP DMA from DMEM/IMEM with overflow

### DIFF
--- a/src/rsp/rsp.rs
+++ b/src/rsp/rsp.rs
@@ -86,7 +86,6 @@ impl RSP {
             SP_STATUS_SET_CLEAR_INTERRUPT_ON_BREAK);
     }
 
-    #[allow(dead_code)]
     pub unsafe fn start_dma_sp_to_cpu(spmem: u32, to: *mut u8, length: u32) {
         Self::set_sp_address(spmem);
         Self::set_dram_address(to as usize as u32);

--- a/src/tests/testlist.rs
+++ b/src/tests/testlist.rs
@@ -907,6 +907,7 @@ fn default_tests() -> Vec<Box<dyn Test>> {
         Box::new(super::sp_memory::dma::SPDMAIntoDMEMWithOverflow {}),
         Box::new(super::sp_memory::dma::SPDMAIntoIMEMUntilEnd {}),
         Box::new(super::sp_memory::dma::SPDMAIntoIMEMWithOverflow {}),
+        Box::new(super::sp_memory::dma::SPDMAFromDMEMWithOverflow {}),
 
         Box::new(super::tlb::WiredRandom {}),
         Box::new(super::tlb::WiredOutOfBoundsRandom {}),


### PR DESCRIPTION
Existing tests covered only using DMEM/IMEM as destination. This test covers using them as source.