### PR TITLE
Fix PI DMA test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "n64-systemtest"
-version = "2.0.2"
+version = "2.0.4"
 dependencies = [
  "arbitrary-int",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "n64-systemtest"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 
 [features]

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -45,14 +45,18 @@ impl MemoryMap {
     }
 
     /// Returns the cartridge (rom) address of a given constant
-    pub fn uncached_cart_address<T>(p: *const T) -> *const T {
+    pub fn physical_cart_address<T>(p: *const T) -> usize {
         // The bootcode copies from 0x10001000 to 0x8000_0400. If we have some other pointer,
         // it doesn't come from the cart
         let memory_address = p as usize;
         assert!(memory_address >= 0x8000_0400);
         assert!(memory_address < 0x8000_0400 + 3 * 1024 * 1024);
 
-        Self::uncached((memory_address + 0x10001000 - 0x400) as *const T)
+        memory_address - 0x8000_0000 + 0x10001000 - 0x400
+    }
+
+    pub fn uncached_cart_address<T>(p: *const T) -> *const T {
+        (Self::physical_cart_address(p) | 0xA000_0000) as *const T
     }
 
     pub fn physical_to_uncached_mut<T>(address: usize) -> *mut T {

--- a/src/tests/cart_memory/dma.rs
+++ b/src/tests/cart_memory/dma.rs
@@ -44,7 +44,7 @@ impl Test for PIDMA {
         Pi::set_status(PiStatusWrite::new().with_reset(true).with_clear_interrupt(true));
         soft_assert_eq(Pi::status(), PiStatusRead::new(), "Pi Status before dma")?;
 
-        let cart_addr = MemoryMap::uncached_cart_address(&DATA[0] as *const u64 as *const u32) as u32;
+        let cart_addr = MemoryMap::physical_cart_address(&DATA[0] as *const u64 as *const u32) as u32;
         let mut target = UncachedHeapMemory::<u32>::new_with_init_value(100, 0);
         let dram_address = target.start_phyiscal() as u32;
         Pi::set_cart_address(cart_addr);


### PR DESCRIPTION
The current version of the test runs a PI DMA from PI address B0xx_xxxx (erroneously using a CPU virtual address in the uncached segment as PI address).

This happens to work on Everdrive X7 because Everdrive possibly reproduces the simplified address decoding logic used by game cartridges, where only bits A27 and A28 are taken into account. So in a way the test would pass if it was flashed into a real mask ROM mounted on a PCB connected to the PI bus via the simplified logic.

64drive and Summercart64 instead do not emulate this kind of simplified address mapping: ROMs are only mapped at 10xx_xxxx.

The goal of this test is to make sure emulators correctly emulate the PI bus. What the N64 RCP PI does is to forward the full 32 bit address from the register to the bus. It is probably better to induce emulators into this kind of behavior (as it's easier to add masking on top, at the cartridge level), rather than making them confused on CPU virtual addresses vs PI addresses.