### PR TITLE
Fix test TLBUseTestReadMatchViaASID

### DIFF
--- a/src/tests/tlb/mod.rs
+++ b/src/tests/tlb/mod.rs
@@ -427,8 +427,8 @@ impl Test for TLBUseTestRead0 {
             cop0::write_tlb(
                 10,
                 0b11 << 13,
-                make_entry_lo(true, true, false, 0, (MemoryMap::HEAP_END >> 12) as u32),
-                make_entry_lo(true, false, false, 0, 0),
+                make_entry_lo(true, true, false, 2, (MemoryMap::HEAP_END >> 12) as u32),
+                make_entry_lo(true, false, false, 2, 0),
                 make_entry_hi(1, u27::new(0xDEA0 >> 1), u2::new(0)))
         }
 
@@ -467,8 +467,8 @@ impl Test for TLBUseTestRead1 {
             cop0::write_tlb(
                 10,
                 0b11 << 13,
-                make_entry_lo(true, false, false, 0, 0),
-                make_entry_lo(true, true, false, 0, (MemoryMap::HEAP_END >> 12) as u32),
+                make_entry_lo(true, false, false, 2, 0),
+                make_entry_lo(true, true, false, 2, (MemoryMap::HEAP_END >> 12) as u32),
                 make_entry_hi(1, u27::new(0xDEA0 >> 1), u2::new(0)))
         }
 
@@ -507,8 +507,8 @@ impl Test for TLBUseTestReadMatchViaASID {
             cop0::write_tlb(
                 10,
                 0b11 << 13,
-                make_entry_lo(false, true, false, 0, (MemoryMap::HEAP_END >> 12) as u32),
-                make_entry_lo(false, false, false, 0, 0),
+                make_entry_lo(false, true, false, 2, (MemoryMap::HEAP_END >> 12) as u32),
+                make_entry_lo(false, false, false, 2, 0),
                 make_entry_hi(1, u27::new(0xDEA0 >> 1), u2::new(0)))
         }
 
@@ -516,10 +516,10 @@ impl Test for TLBUseTestReadMatchViaASID {
         unsafe { cop0::set_entry_hi(1); }
 
         // Write a value without TLB
-        unsafe { ((MemoryMap::HEAP_END_VIRTUAL_UNCACHED + 0x18) as *mut u32).write_volatile(0xCAFFEEDE); }
+        unsafe { ((MemoryMap::HEAP_END_VIRTUAL_UNCACHED + 0x18) as *mut u32).write_volatile(0xCAFFEE11); }
 
         // Read it back using the TLB
-        soft_assert_eq(unsafe { (0x0DEA0018 as *mut u32).read_volatile() }, 0xDECAFBAD, "Value read back through TLB mapped memory")?;
+        soft_assert_eq(unsafe { (0x0DEA0018 as *mut u32).read_volatile() }, 0xCAFFEE11, "Value read back through TLB mapped memory")?;
 
         Ok(())
     }


### PR DESCRIPTION
This test was broken: It read from cached memory so it actually ignored the value that was written. Instead, it used the value of the previous test.

Fix this by picking a different magic value and by switching the tlb areas to uncached.