### PR TITLE
Instruct users to install nust64 using stable rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd n64-systemtest
 ```
 3. Install prerequisites:
 ```
-cargo install nust64
+cargo +stable install nust64
 ```
 4. Run `cargo run --release` to build the test rom.
 


### PR DESCRIPTION
Resolves #85 

Installing the `nust64` dependency, while inside the project's root directory, will cause cargo to use the project's toolchain version instead of stable. An intermediate dependency no longer compiles on the old unstable version this project uses.

Since `nust64` can compile fine on stable rust, we can instruct people to install it via stable instead.

---

Changing the toolchain version would also "fix" this issue. But, doing so may require a lot more effort than a README change, and this problem might crop up again in the future for the same reason.